### PR TITLE
changes to support DBS Go server backend

### DIFF
--- a/tests/dbsclient_t/unittests/DBSClientReaderGo_t.py
+++ b/tests/dbsclient_t/unittests/DBSClientReaderGo_t.py
@@ -1,0 +1,92 @@
+"""
+aggregation/stream unittests
+"""
+
+import os
+import sys
+import unittest
+
+from dbs.apis.dbsClient import parseStream, aggAttribute, \
+        aggRuns, aggReleaseVersions, aggDatasetAccessTypes, \
+        aggFileLumis, aggFileParents, aggFileChildren
+
+class DBSClientReaderGo_t(unittest.TestCase):
+
+    def __init__(self, methodName='runGoTest'):
+        super(DBSClientReaderGo_t, self).__init__(methodName)
+
+    def testParseStream(self):
+        """test parseStream function"""
+        results = """{"foo":1}\n{"foo":2}\n{"foo":3}\n"""
+        data = [r for r in parseStream(results)]
+        self.assertTrue(len(data) == 3)
+        values = []
+        for rec in data:
+            values.append(rec["foo"])
+        self.assertTrue(values == [1, 2, 3])
+
+    def testAggAttribute(self):
+        """test aggAttribute function"""
+        data = [{"foo":1, "x":1}, {"foo":2, "x":1}, {"foo":3, "x":1}]
+        results = aggAttribute(data, "foo")
+        self.assertTrue(results, [{"foo":[1,2,3], "x":1}])
+
+    def testAggRuns(self):
+        """test aggRuns function"""
+        data = [{"run_num":1, "x":1}, {"run_num":2, "x":1}, {"run_num":3, "x":1}]
+        results = aggRuns(data)
+        self.assertTrue(results, [{"run_num":[1,2,3], "x":1}])
+
+    def testAggReleaseVersions(self):
+        """test aggReleaseVersions function"""
+        data = [{"release_version":1, "x":1}, {"release_version":2, "x":1}, {"release_version":3, "x":1}]
+        results = aggReleaseVersions(data)
+        self.assertTrue(results, [{"release_version":[1,2,3], "x":1}])
+
+    def testAggDatasetAccessTypes(self):
+        """test aggDatasetAccessTypes function"""
+        data = [{"dataset_access_type":1, "x":1}, {"dataset_access_type":2, "x":1}, {"dataset_access_type":3, "x":1}]
+        results = aggDatasetAccessTypes(data)
+        self.assertTrue(results, [{"dataset_access_type":[1,2,3], "x":1}])
+
+    def testAggFileLumis(self):
+        """test aggFileLumis function"""
+        data = [
+            {"logical_file_name":"lfn","lumi_section_num":1,"run_num":97},
+            {"logical_file_name":"lfn","lumi_section_num":12,"run_num":98},
+            {"logical_file_name":"lfn","lumi_section_num":13,"run_num":99}
+        ]
+        results = aggFileLumis(data)
+        self.assertTrue(results, [{"logical_file_name": "lfn", "lumi_section_num":[1,2,3], "run_num":1}])
+
+    def testAggFileParents(self):
+        """test aggFileParents function"""
+        data = [
+            {"logical_file_name":"lfn1", "parent_logical_file_name":"parent1"},
+            {"logical_file_name":"lfn1", "parent_logical_file_name":"parent2"},
+            {"logical_file_name":"lfn2", "parent_logical_file_name":"parent3"}
+        ]
+        results = aggFileParents(data)
+        expect = [
+            {"logical_file_name":"lfn1", "parent_logical_file_name": ["parent1", "parent2"]},
+            {"logical_file_name":"lfn2", "parent_logical_file_name": ["parent3"]}
+        ]
+        self.assertTrue(results, expect)
+
+    def testAggFileChildren(self):
+        """test aggFileChildren function"""
+        data = [
+            {"logical_file_name":"lfn1", "child_logical_file_name":"child1"},
+            {"logical_file_name":"lfn1", "child_logical_file_name":"child2"},
+            {"logical_file_name":"lfn2", "child_logical_file_name":"child3"}
+        ]
+        results = aggFileChildren(data)
+        expect = [
+            {"logical_file_name":"lfn1", "child_logical_file_name": ["child1", "child2"]},
+            {"logical_file_name":"lfn2", "child_logical_file_name": ["child3"]}
+        ]
+        self.assertTrue(results, expect)
+
+if __name__ == "__main__":
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(DBSClientReaderGo_t)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
@yuyiguo I ported changes to make them compatible with your dmwm/DBSClient  DBSClient4go branch. Please note git informed me that there is a mix of tabs/spaces in original code and I suggest that you solve it separately.

I also run unit tests as following
```
python3 tests/dbsclient_t/unittests/DBSClientReaderGo_t.py
testAggAttribute (__main__.DBSClientReaderGo_t)
test aggAttribute function ... ok
testAggDatasetAccessTypes (__main__.DBSClientReaderGo_t)
test aggDatasetAccessTypes function ... ok
testAggFileChildren (__main__.DBSClientReaderGo_t)
test aggFileChildren function ... ok
testAggFileLumis (__main__.DBSClientReaderGo_t)
test aggFileLumis function ... ok
testAggFileParents (__main__.DBSClientReaderGo_t)
test aggFileParents function ... ok
testAggReleaseVersions (__main__.DBSClientReaderGo_t)
test aggReleaseVersions function ... ok
testAggRuns (__main__.DBSClientReaderGo_t)
test aggRuns function ... ok
testParseStream (__main__.DBSClientReaderGo_t)
test parseStream function ... ok

----------------------------------------------------------------------
Ran 8 tests in 0.001s

OK
```