### PR TITLE
Adjust setup_test.py to work with reader/writer options

### DIFF
--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -106,9 +106,9 @@ class TestCommand(Command):
         self.insert = None
         self.cmsweb_testbed = None
         self.host = None
-        self.reader = None
-        self.writer = None
-        self.migrate = None
+        self.reader = ""
+        self.writer = ""
+        self.migrate = ""
 
     def finalize_options(self):
         #Check if environment us set-up correctly
@@ -145,18 +145,21 @@ class TestCommand(Command):
                         'https://cmsweb.cern.ch': 'prod/test'}
 
         ###set environment
-        os.environ['DBS_READER_URL'] = ("%s/dbs/%s/DBSReader") % (self.host, db_instances.get(self.host, 'dev/global'))
-        os.environ['DBS_WRITER_URL'] = ("%s/dbs/%s/DBSWriter") % (self.host, db_instances.get(self.host, 'dev/global'))
-        os.environ['DBS_MIGRATE_URL'] = ("%s/dbs/%s/DBSMigrate") % (self.host,
-                                                                    db_instances.get(self.host, 'dev/global'))
         
         # if user provide specific reader/writer/migrate url we'll use them
         if self.reader != "":
             os.environ['DBS_READER_URL'] = self.reader
+        else:
+            os.environ['DBS_READER_URL'] = ("%s/dbs/%s/DBSReader") % (self.host, db_instances.get(self.host, 'dev/global'))
         if self.writer != "":
             os.environ['DBS_WRITER_URL'] = self.writer
+        else:
+            os.environ['DBS_WRITER_URL'] = ("%s/dbs/%s/DBSWriter") % (self.host, db_instances.get(self.host, 'dev/global'))
         if self.migrate != "":
             os.environ['DBS_MIGRATE_URL'] = self.migrate
+        else:
+            os.environ['DBS_MIGRATE_URL'] = ("%s/dbs/%s/DBSMigrate") % (self.host,
+                                                                        db_instances.get(self.host, 'dev/global'))
 
         if self.cmsweb_testbed:
             self.unitall, self.validation, self.deployment = (True, True, True)


### PR DESCRIPTION
@yuyiguo thank you for merging https://github.com/dmwm/DBSClient/pull/26. Once I tried to run new `setup_test.py` in my local env (laptop) I identified that additional changes are required. This PR provides:
- fix for `self.reader/writer/migrate` type to be a string (as they should be used in env assigment)
- add proper condition `if/else` when these options are in use

Please review and merge this PR. With it I was able to run `DBSClientReader` tests against `https://cmsweb-testbed.cern.ch/dbs2go` URL from my local laptop.