### PR TITLE
Check output[key] type before applying sort function

### DIFF
--- a/tests/dbsclient_t/validation/DBSValidation_t.py
+++ b/tests/dbsclient_t/validation/DBSValidation_t.py
@@ -362,22 +362,28 @@ class DBSValidation_t(unittest.TestCase):
                                 print("key %s has valut %s in input data" % (key, value))
 #                                 self.assertEqual(value, output[key])
                     if key == "file_lumi_list":
-                        output[key].sort(key=lambda x: x.get('lumi_section_num'))
+                        if isinstance(output[key], list):
+                            output[key].sort(key=lambda x: x.get('lumi_section_num'))
                         value.sort(key=lambda x: x.get('lumi_section_num'))
                     elif key == "dataset_conf_list":
-                        output[key].sort(key=lambda x: x.get('output_module_label') + str(x.get('creation_date')))
+                        if isinstance(output[key], list):
+                            output[key].sort(key=lambda x: x.get('output_module_label') + str(x.get('creation_date')))
                         value.sort(key=lambda x: x.get('output_module_label') + str(x.get('creation_date')))
                     elif key == "file_parent_list":
-                        output[key].sort(key=lambda x: x.get('parent_logical_file_name') + x.get('this_logical_file_name'))
+                        if isinstance(output[key], list):
+                            output[key].sort(key=lambda x: x.get('parent_logical_file_name') + x.get('this_logical_file_name'))
                         value.sort(key=lambda x: x.get('parent_logical_file_name') + x.get('this_logical_file_name'))
                     elif key == "file_conf_list":
-                        output[key].sort(key=lambda x: x.get('lfn'))
+                        if isinstance(output[key], list):
+                            output[key].sort(key=lambda x: x.get('lfn'))
                         value.sort(key=lambda x: x.get('lfn'))
                     elif key == "files":
-                        output[key].sort(key=lambda x: x.get('logical_file_name'))
+                        if isinstance(output[key], list):
+                            output[key].sort(key=lambda x: x.get('logical_file_name'))
                         value.sort(key=lambda x: x.get('logical_file_name'))
                     elif key == "block_parent_list":
-                        output[key].sort(key=lambda x: x.get('parent_block_name'))
+                        if isinstance(output[key], list):
+                            output[key].sort(key=lambda x: x.get('parent_block_name'))
                         value.sort(key=lambda x: x.get('parent_block_name'))
 
                     check(value, output[key])


### PR DESCRIPTION
The return data-type in JSON for empty results set, e.g. file_parent_list, can be presented differently. Python server returns empty list (`[]`), while Go JSON decoder returns `null` if there is results in that structure. The unit test should check first the data type before applying sort function.