### PR TITLE
Improve handling of HTTP response when it is not in JSON form

### DIFF
--- a/src/python/dbs/apis/dbsClient.py
+++ b/src/python/dbs/apis/dbsClient.py
@@ -10,6 +10,19 @@ import socket
 import sys
 import urllib.request, urllib.parse, urllib.error
 
+def headerHas(headers, content, mime):
+    """
+    Check mime content in HTTP headers which represented as multi line string.
+    The content is pattern a particular header should start with and mime
+    is a value of the content. For instance, a typical usage is to check if
+    given content type exists in HTTP Header, e.g. Content-Type: application/json
+    """
+    for hdr in headers.split('\n'):
+        if content.lower() in hdr.lower():
+            if mime.lower() in hdr.lower():
+                return True
+    return False
+
 def parseStream(results):
     """
     Parse given stream of results
@@ -363,6 +376,7 @@ class DbsApi(object):
         self.accept = accept
         self.aggregate = aggregate
         self.debug = debug
+        self.http_response = None
 
         self.rest_api = RestApi(auth=X509Auth(ssl_cert=cert, ssl_key=key, ssl_verifypeer=verifypeer, ca_info=ca_info),
                                 proxy=Socks5Proxy(proxy_url=self.proxy) if self.proxy else None)
@@ -400,7 +414,17 @@ class DbsApi(object):
                 print("HTTP={} URL={} method={} params={} data={} headers={}".format(callmethod, self.url, method, params, data, request_headers))
             self.http_response = method_func(self.url, method, params, data, request_headers)
         except HTTPError as http_error:
-            self.__parseForException(http_error)
+            if headerHas(http_error.header, 'Content-Type', 'application/json'):
+                self.__parseForException(http_error)
+            else:
+                msg = "\nURL={}\nCode={}\nMessage={}\nHeader={}\nBody={}\n".format(
+                        http_error.url,
+                        http_error.code,
+                        http_error.msg,
+                        http_error.header,
+                        http_error.body)
+                data = HTTPError(http_error.url, http_error.code, msg, http_error.header, http_error.body)
+                self.__parseForException(data)
 
         if self.accept == "application/ndjson":
             return parseStream(self.http_response.body)
@@ -411,7 +435,7 @@ class DbsApi(object):
             json_ret=json.loads(self.http_response.body)
         except ValueError as ex:
             print("The server output is not a valid json, most probably you have a typo in the url.\n%s.\n" % self.url, file=sys.stderr)
-            raise dbsClientException("Invalid url", "Possible urls are %s" %self.http_response.body)
+            raise dbsClientException("Invalid url", "Possible urls are %s" % self.http_response.body)
 
         if self.aggregate and aggFunc:
             return aggFunc(json_ret)


### PR DESCRIPTION
Currently, DBSClient incorrectly handle JSON decoding errors when the data input does not represent JSON. For example,  the following code:
```
from dbs.apis.dbsClient import *

url="https://cmsweb-testbed.cern.ch/dbs/bla/DBSReader"
api = DbsApi(url=url, debug=1)
res = api.help()
print(res)
```
will produce the following error:
```
HTTP=GET URL=https://cmsweb-testbed.cern.ch:8443/dbs/bla/DBSReader method=help params={} data={} headers={'Content-Type': 'application/json', 'Accept': 'application/json', 'UserID': 'vk@vkair', 'User-Agent': 'DBSClient/Unknown/'}
Traceback (most recent call last):
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/./t.py", line 6, in <module>
    res = api.help()
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 496, in help
    return self.__callServer("help", params=kwargs)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 403, in __callServer
    self.__parseForException(http_error)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 429, in __parseForException
    raise http_error
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 401, in __callServer
    self.http_response = method_func(self.url, method, params, data, request_headers)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/dbs3-pycurl-3.17.4/src/python/RestClient/RestApi.py", line 34, in get
    return http_request(self._curl)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/dbs3-pycurl-3.17.4/src/python/RestClient/RequestHandling/HTTPRequest.py", line 62, in __call__
    raise HTTPError(effective_url, http_code, http_response.msg, http_response.raw_header, http_response.body)
RestClient.ErrorHandling.RestClientExceptions.HTTPError: HTTP Error 400: Bad Request
```
Depending on return data it may be difficult to understand what exactly data had since the data is not returned by Python exception.

The proposed PR improve error handling by checking the actual HTTP code and if it is not 200, it can return the actual data including all details of HTTP request. For instance, running the same code we will get the following output:
```
HTTP=GET URL=https://cmsweb-testbed.cern.ch:8443/dbs/bla/DBSReader method=help params={} data={} headers={'Content-Type': 'application/json', 'Accept': 'application/json', 'UserID': 'vk@vkair', 'User-Agent': 'DBSClient/Unknown/'}
### HTTPError ###
URL: https://cmsweb-testbed.cern.ch:8443/dbs/bla/DBSReader/help
HTTP code: 400
HTTP Message: Bad Request
HTTP Header: HTTP/1.1 400 Bad Request
Date: Thu, 11 Nov 2021 14:21:01 GMT
Server: Apache
Content-Length: 226
Connection: close
Content-Type: text/html; charset=iso-8859-1


HTTP Body
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>400 Bad Request</title>
</head><body>
<h1>Bad Request</h1>
<p>Your browser sent a request that this server could not understand.<br />
</p>
</body></html>

Traceback (most recent call last):
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/./t.py", line 6, in <module>
    res = api.help()
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 506, in help
    return self.__callServer("help", params=kwargs)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 413, in __callServer
    raise http_error
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/src/python/dbs/apis/dbsClient.py", line 402, in __callServer
    self.http_response = method_func(self.url, method, params, data, request_headers)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/dbs3-pycurl-3.17.4/src/python/RestClient/RestApi.py", line 34, in get
    return http_request(self._curl)
  File "/Users/vk/CMS/DMWM/GIT/DBSClient/dbs3-pycurl-3.17.4/src/python/RestClient/RequestHandling/HTTPRequest.py", line 62, in __call__
    raise HTTPError(effective_url, http_code, http_response.msg, http_response.raw_header, http_response.body)
RestClient.ErrorHandling.RestClientExceptions.HTTPError: HTTP Error 400: Bad Request
```

Now, the output provide all details of HTTP response and preserve the same Python exception.

These modifications will be extremely useful in order to understand the actual error. For instance, if timeout happens on cmsweb frontends currently we have the following error:
```
Traceback (most recent call last):
  File "/data/users/vk/dbs/DBS/DBSClient/src/python/dbs/apis/dbsClient.py", line 440, in __parseForException
    data = json.loads(data)
  File "/data/users/vk/anaconda3/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/data/users/vk/anaconda3/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/data/users/vk/anaconda3/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/data/users/vk/dbs/DBS/DBSClient/tests/dbsclient_t/validation/DBSValidation_t.py", line 648, in test16
    result2 = self.cmswebtestbed_api.listFileParentsByLumi(block_name=block["block_name"])
  File "/data/users/vk/dbs/DBS/DBSClient/src/python/dbs/apis/dbsClient.py", line 737, in listFileParentsByLumi
    return self.__callServer("fileparentsbylumi", data=kwargs, callmethod='POST', aggFunc=aggFileParentsByLumi)
  File "/data/users/vk/dbs/DBS/DBSClient/src/python/dbs/apis/dbsClient.py", line 404, in __callServer
    self.__parseForException(http_error)
  File "/data/users/vk/dbs/DBS/DBSClient/src/python/dbs/apis/dbsClient.py", line 442, in __parseForException
    raise http_error
  File "/data/users/vk/dbs/DBS/DBSClient/src/python/dbs/apis/dbsClient.py", line 402, in __callServer
    self.http_response = method_func(self.url, method, params, data, request_headers)
  File "/data/users/vk/dbs/DBS/DBSClient/dbs3-pycurl-3.17.4/src/python/RestClient/RestApi.py", line 40, in post
    return http_request(self._curl)
  File "/data/users/vk/dbs/DBS/DBSClient/dbs3-pycurl-3.17.4/src/python/RestClient/RequestHandling/HTTPRequest.py", line 62, in __call__
    raise HTTPError(effective_url, http_code, http_response.msg, http_response.raw_header, http_response.body)
RestClient.ErrorHandling.RestClientExceptions.HTTPError: HTTP Error 502: Proxy Error
```
This error contains two exceptions, one from HTTPError and another from JSON decoder parser. But it does not provide any detail of HTTP response. For average user this error is very cryptic and hard to understand.
```