### PR TITLE
Changes to pass DBS validation tests and fix test of checking serverinfo API

### DIFF
--- a/tests/dbsclient_t/unittests/DBSClientReader_t.py
+++ b/tests/dbsclient_t/unittests/DBSClientReader_t.py
@@ -1484,8 +1484,16 @@ class DBSClientReader_t(unittest.TestCase):
         """test107: unittestDBSClientReader_t.serverinfo: get server info"""
         reg_ex = r'^(3+\.[0-9]+\.[0-9]+[\.\-a-z0-9]*$)'
         version = self.api.serverinfo()
-        self.assertTrue('dbs_version' in version)
-        self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)
+        if isinstance(version, dict):
+            # python server
+            self.assertTrue('dbs_version' in version)
+            self.assertFalse(re.compile(reg_ex).match(version['dbs_version']) is None)
+        elif isinstance(version, list):
+            # go server
+            info = version[0]
+            reg_ex = r'^v\d\d\.\d\d\.\d\d'
+            self.assertTrue('dbs_version' in info)
+            self.assertFalse(re.compile(reg_ex).match(info['dbs_version']) is None)
 
     def test108(self):
         """test108 unittestDBSClientReader_t.listFileParentsByLumi: basic test using lumi section info"""


### PR DESCRIPTION
@yuyiguo I made separate PR to address changes required to pass DBS Validation tests. The changes reflects difference in API output and behavior between two implementations. Please review. For instance, in new implementation I added `/process` API for DBS Migration server to distinguish it from `/submit`. The former process existing request, while later only submit a request. With these set of changes I was able to pass all DBSMigration_t tests.