### PR TITLE
Strip ending slashes from the DbsApi url

### DIFF
--- a/src/python/dbs/apis/dbsClient.py
+++ b/src/python/dbs/apis/dbsClient.py
@@ -380,10 +380,14 @@ class DbsApi(object):
            By default the DbsApi is trying to lookup the private key and the certificate in the common locations
 
         """
+        if isinstance(url, bytes):
+            url = url.decode("utf-8")
         if url.find(":", 6) == -1:
             self.url = url.replace(".cern.ch/dbs/", ".cern.ch:" + str(port) + "/dbs/", 1)
         else:
             self.url = url
+        # avoid double slash in the final URI
+        self.url = self.url.rstrip("/")
         self.proxy = proxy
         self.key = key
         self.cert = cert


### PR DESCRIPTION
Fixes https://github.com/dmwm/DBSClient/issues/55

In addition to stripping ending slashes from the DBS url, this patch also ensures that the `url` is of the type `str`, otherwise an exception would be raised when executing `url.find`.

I just tested this patch and it resolves the problem.

Related to: https://github.com/dmwm/WMCore/issues/10883