### PR TITLE
Changes required for Go based DBSMigrate server tests and custom DBSeader

### DIFF
--- a/tests/dbsclient_t/validation/DBSValidation_t.py
+++ b/tests/dbsclient_t/validation/DBSValidation_t.py
@@ -42,9 +42,12 @@ flist = []
 
 def GoServer(api):
     "Test if given DBS API talks to Go Server or not"
-    res = api.serverinfo()
-    if 'dbs2go' in str(res):
-        return True
+    try:
+        res = api.serverinfo()
+        if 'dbs2go' in str(res):
+            return True
+    except:
+        pass
     return False
 
 def remove_non_comparable_keys(values, non_comparable_keys):
@@ -65,13 +68,14 @@ class DBSValidation_t(unittest.TestCase):
             self.setUpClass()
         url = os.environ['DBS_WRITER_URL']
         proxy = os.environ.get('SOCKS5_PROXY')
-        self.debug = os.environ.get('DBS_DEBUG')
+        self.debug = os.environ.get('DBS_DEBUG', False)
         self.api = DbsApi(url=url, proxy=proxy, debug=self.debug)
         migration_url = os.environ['DBS_MIGRATE_URL']
         self.migration_api = DbsApi(url=migration_url, proxy=proxy, debug=self.debug)
         self.source_url='https://cmsweb.cern.ch:8443/dbs/prod/global/DBSReader'
         self.cmsweb_api = DbsApi(url=self.source_url, proxy=proxy, debug=self.debug)
-        self.cmswebtestbed_api = DbsApi(url='https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader', proxy=proxy)
+        readerUrl = os.environ.get('DBS_READER_URL', 'https://cmsweb-testbed.cern.ch/dbs/int/global/DBSReader')
+        self.cmswebtestbed_api = DbsApi(url=readerUrl, proxy=proxy)
 
     def setUp(self):
         """setup all necessary parameters"""
@@ -504,7 +508,7 @@ class DBSValidation_t(unittest.TestCase):
                     elif key == "block_parent_list":
                         if output[key]:
                             output[key].sort(key=lambda x: x.get('parent_block_name'))
-                        value.sort(key=lambda x: x.get('parent_block_name'))
+                        value.sort(key=lambda x: x.get('parent_block_name', ""))
 
                     check(value, output[key])
             elif isinstance(input, list):


### PR DESCRIPTION
@yuyiguo , I made these changes in order to pass DBS migration tests using the following command:
```
python3 setup_test.py test_system --host=https://cmsweb-testbed.cern.ch --reader=https://cmsweb-testbed.cern.ch/dbs2go --writer=https://cmsweb-testbed.cern.ch/dbs2go-writer --migrate=https://cmsweb-testbed.cern.ch/dbs2go-migrate --validation
```
In this test I used custom DBS server end-points, `/dbs2go` for DBSReader, `/dbs2go-writer` for DBSWriter and `/dbs2go-migrate` for DBSMigrate servers. With proposed changes all migration tests are passed ok.