### PR TITLE
Check data-type of fileLumisList

### DIFF
--- a/src/python/dbs/apis/dbsClient.py
+++ b/src/python/dbs/apis/dbsClient.py
@@ -607,8 +607,12 @@ class DbsApi(object):
         if len(blockDump['files']) > 0:
             fileLumiList = blockDump['files'][0]['file_lumi_list']
             if len(fileLumiList) > 0:
-                if fileLumiList.get('event_count') == None:
+                if isinstance(fileLumisList, dict) and fileLumiList.get('event_count') == None:
                     frst = False
+                elif isinstance(fileLumisList, list):
+                    flDict = fileLumiList[0]
+                    if isinstance(flDict, dict) and flDict.get('event_count') == None:
+                        frst = False
         # when frst == True, we are looking for event_count == None in the data, if we did not find None (redFlg = False),
         # eveything is good. Otherwise, we have to remove all even_count in lumis and raise exception.
         # when frst == False, weare looking for event_count != None in the data, if we did not find Not None (redFlg = False),        # everything is good. Otherwise, we have to remove all even_count in lumis and raise exception.


### PR DESCRIPTION
In order to extract element from the dict we need to ensure that provided object is indeed a dict data-type. This PR provides this fix for issue https://github.com/dmwm/CRABServer/issues/7378