### PR TITLE
Update pycurl dependency from 7.43.0.6 to 7.45.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pycurl~=7.43.0.6
-dbs3-pycurl==3.17.7
+dbs3-pycurl==3.17.8


### PR DESCRIPTION
As mentioned here:
https://github.com/dmwm/WMCore/issues/11327#issuecomment-1272037171

there is an incompatibility between WMCore and DBSClient, pulling different versions of the `pycurl` library.
This PR updates the pycurl version in `dbs3-client` package to `7.45.1`

@vkuznet please review and cut a new release.