### PR TITLE
Properly handle DBS Go server errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dbs3-pycurl==3.17.8
+dbs3-pycurl==3.17.9

--- a/src/python/dbs/apis/dbsClient.py
+++ b/src/python/dbs/apis/dbsClient.py
@@ -502,15 +502,16 @@ class DbsApi(object):
             print("DBS Server error:", data)
             # extract DBS Go server code
             server_code = 0
-            if hasattr(data, "error"):
-                dbsErr = data['error']
-                server_code = getattr(dbsErr, 'code', 0)
             # re-raise with more detail
             if isinstance(data, dict) and 'exception' in data:
+                dbsErr = data.get('error', {})
+                server_code = dbsErr.get('code', 0)
                 raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body, server_code)
             # DBS go server provides errors as list data-type
             if isinstance(data, list) and len(data) == 1 and 'exception' in data[0]:
                 data = data[0]
+                dbsErr = data.get('error', {})
+                server_code = dbsErr.get('code', 0)
                 raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body, server_code)
         except:
             raise http_error

--- a/src/python/dbs/apis/dbsClient.py
+++ b/src/python/dbs/apis/dbsClient.py
@@ -500,13 +500,18 @@ class DbsApi(object):
         try:
             data = json.loads(data)
             print("DBS Server error:", data)
+            # extract DBS Go server code
+            server_code = 0
+            if hasattr(data, "error"):
+                dbsErr = data['error']
+                server_code = getattr(dbsErr, 'code', 0)
             # re-raise with more detail
             if isinstance(data, dict) and 'exception' in data:
-                raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body)
+                raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body, server_code)
             # DBS go server provides errors as list data-type
             if isinstance(data, list) and len(data) == 1 and 'exception' in data[0]:
                 data = data[0]
-                raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body)
+                raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body, server_code)
         except:
             raise http_error
         raise http_error

--- a/src/python/dbs/apis/dbsClient.py
+++ b/src/python/dbs/apis/dbsClient.py
@@ -503,6 +503,10 @@ class DbsApi(object):
             # re-raise with more detail
             if isinstance(data, dict) and 'exception' in data:
                 raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body)
+            # DBS go server provides errors as list data-type
+            if isinstance(data, list) and len(data) == 1 and 'exception' in data[0]:
+                data = data[0]
+                raise HTTPError(http_error.url, data['exception'], data['message'], http_error.header, http_error.body)
         except:
             raise http_error
         raise http_error


### PR DESCRIPTION
This PR contains changes required to properly handle DBS GO errors. In Go server all HTTP response represented in list data type, including server error. Therefore, DBSClient code should properly extract first element of returned list and provide proper HTTPError.